### PR TITLE
Fixed compatibility issues introduced by Sketch 39

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,13 @@ Usage
     > Shortcut: Command + Option + Shift + E
 
     ![menu](https://cloud.githubusercontent.com/assets/931655/9568280/ad573d6c-4f7f-11e5-903a-c9bb10c31040.png)
-    
+
 3. Enter sizes and click OK.
     > Default: `29, 40, 60` for size and `2, 3` for scale. (iOS App)
 
     ![prompt](https://cloud.githubusercontent.com/assets/931655/11877130/b6a3057a-a530-11e5-9385-cf8585a53b9b.png)
 
 4. Export sizes are created.
-    > UI does not refresh automatically. You should click empty background and click layer again to see the results.
 
     ![export](https://cloud.githubusercontent.com/assets/931655/11877222/3bf9731c-a531-11e5-8f92-367c92b7122d.png)
 

--- a/sketch-export-sizes-generator.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/sketch-export-sizes-generator.sketchplugin/Contents/Sketch/script.cocoascript
@@ -30,7 +30,6 @@ var SCALES = []; // e.g. [1, 2]
 var LABEL_WIDTH = 50;
 var INPUT_WIDTH = 200;
 
-
 function createLabelAtIndex(index, text) {
   var y = 30 * index + 5;
   var label = [[NSTextField alloc] initWithFrame:NSMakeRect(0, y, LABEL_WIDTH, 0)];
@@ -115,8 +114,8 @@ function compare(a, b) {
 function prepareExportSizes(layer) {
   log('=== ' + layer.name() + ' ===');
   log('Remove all export sizes of layer \'' + layer.name() + '\'.');
-  var sizes = layer.exportOptions().sizes();
-  sizes.removeAllObjects();
+  var sizes = layer.exportOptions().exportFormats();
+  layer.exportOptions().removeAllExportFormats();
 
   SIZES.sort(compare);
   SCALES.sort(compare);
@@ -131,10 +130,6 @@ function prepareExportSizes(layer) {
       addExportSize(layer, height, suffix);
     }
   }
-
-  // add and remove a new export size to refresh UI
-  layer.exportOptions().addExportSize();
-  sizes.removeObjectAtIndex(sizes.count() - 1));
 }
 
 
@@ -145,8 +140,8 @@ function addExportSize(layer, height, suffix, format) {
 
   log('Add \'' + layer.name() + suffix + '\' (' + height + 'h' + ')');
 
-  var size = layer.exportOptions().addExportSize();
-  size.setFormat(format);
+  var size = layer.exportOptions().addExportFormat();
+  size.setFileFormat(format);
   size.setName(suffix);
   size.setScale(height / layer.frame().size().height);
   size.setVisibleScaleType(2); // e.g. 512h
@@ -155,6 +150,7 @@ function addExportSize(layer, height, suffix, format) {
 var onRun = function(context) {
   var selectedLayers = context.selection;
   var selectedCount = selectedLayers.count();
+  var doc = context.document;
 
   if (selectedCount == 0) {
     log('No layers are selected.');
@@ -176,10 +172,15 @@ var onRun = function(context) {
 
   for (var i = 0; i < selectedCount; i++) {
     var layer = selectedLayers[i];
+    log(layer.name());
     if (i != 0) {
       log('');
     }
     prepareExportSizes(layer);
+
+    // deselect and reselect all layers to force refresh UI
+    doc.currentPage().deselectAllLayers();
+    [layer select:true byExpandingSelection:true];
   }
 
   log('\nDone.');

--- a/sketch-export-sizes-generator.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/sketch-export-sizes-generator.sketchplugin/Contents/Sketch/script.cocoascript
@@ -172,7 +172,7 @@ var onRun = function(context) {
 
   for (var i = 0; i < selectedCount; i++) {
     var layer = selectedLayers[i];
-    log(layer.name());
+    
     if (i != 0) {
       log('');
     }


### PR DESCRIPTION
Function names have been changed since Sketch 39, so I changed those and I moved the refresh UI action too since the old one wasn't working anymore too.
